### PR TITLE
Avoid fatal errors when resending to an existing recipient

### DIFF
--- a/CRM/Resendmailing/BAO/Resendmailing.php
+++ b/CRM/Resendmailing/BAO/Resendmailing.php
@@ -1,0 +1,58 @@
+<?php
+
+use CRM_Resendmailing_ExtensionUtil as E;
+
+class CRM_Resendmailing_BAO_Resendmailing {
+
+  /**
+   * Deletes an existing civicrm_activity_contact record to avoid a
+   * "DB error: already exists" fatal error, which can lead to other bugs.
+   *
+   * A lot of code here is copied from CRM_Mailing_BAO_MailingJob::writeToDB().
+   */
+  public static function deleteExistingActivityContactRecord($params) {
+    $mailing = \Civi\Api4\Mailing::get(FALSE)
+      ->addSelect('sms_provider_id')
+      ->addWhere('id', '=', $params['mailing_id'])
+      ->execute()
+      ->single();
+
+    if ($mailing->sms_provider_id) {
+      $activityTypeID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Mass SMS');
+    }
+    else {
+      $activityTypeID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Bulk Email');
+    }
+    if (!$activityTypeID) {
+      throw new CRM_Core_Exception(ts('No relevant activity type found when recording Mailing Event delivered Activity'));
+    }
+
+    // Fetch the activity linked to this mailing
+    $query = "SELECT id
+      FROM civicrm_activity
+      WHERE civicrm_activity.activity_type_id = %1
+        AND civicrm_activity.source_record_id = %2";
+ 
+    $activityID = CRM_Core_DAO::singleValueQuery($query, [
+      1 => [$activityTypeID, 'Positive'], 
+      2 => [$params['mailing_id'], 'Positive'], 
+    ]);
+
+    $targetRecordID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Targets');
+
+    if ($activityID) {
+      // Delete the existing record, because writeToDB will re-create it
+      $sql = "DELETE FROM civicrm_activity_contact
+        WHERE activity_id = %1
+          AND contact_id = %2
+          AND record_type_id = %3";
+
+      CRM_Core_DAO::executeQuery($sql, [
+        1 => [$activityID, 'Positive'],
+        2 => [$params['contact_id'], 'Positive'],
+        3 => [$targetRecordID, 'Positive'],
+      ]);
+    }
+  }
+
+}


### PR DESCRIPTION
I ran into #3 and could reproduce it fairly systematically:

- Send a mailing to some recipients normally (not using this extension)
- Then use this extension to resend the mailing to a single contact
- and then resend to them again (using the same form)

For the problem to happen, activity creation must be enabled (which is the CiviCRM default, iirc).

The interface would show "DB error: already exists", this is because of `writeToDB` which checks if an activity already exists for the mailing, and if so, it adds the contact as a target to that activity. If they already received the mailing, then it causes a duplicate, which the DB prevents because of unique indexes.

And then, for some mysterious reason which could only be found in the forgotten depths of old BAOs, CiviCRM resends the mailing to all the original recipients of the mailing.